### PR TITLE
ci: add release please

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Pypi Publish
 on:
   release:
     types:
-      - created
+      - published
 env:
   HATCH_INDEX_AUTH: ${{ secrets.HATCH_INDEX_AUTH }}
   HATCH_INDEX_USER: ${{ secrets.HATCH_INDEX_USER }}
@@ -14,28 +14,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
-      - name: Extract Release Name
-        run: echo "RELEASE_NAME=$(echo $GITHUB_REF | sed -n 's/refs\/tags\///p')" >> $GITHUB_ENV
       - name: Install hatch
         run: pip install hatch
       - name: Publish to Pypi
         run: |
-          hatch version $RELEASE_NAME
+          hatch version
           hatch build
           hatch publish -n
-      - name: Checkout Main
-        run: |
-          git fetch
-          git stash
-          git checkout main
-          git stash apply
-      - name: Add & Commit
-        uses: EndBug/add-and-commit@v9.1.3
-        with:
-          add: 'src/flask_muck/__init__.py'
-          push: origin main --force
-

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,22 @@
+on:
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+name: release-please
+
+jobs:
+  release-please:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        with:
+          # in order to trigger other actions such as Pypi Publish
+          # need to use a PAT other than the default GITHUB_TOKEN
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          release-type: python

--- a/README.md
+++ b/README.md
@@ -104,6 +104,26 @@ All non-bug-related discussions such as support or feature requests should be su
 
 MIT licensed. See the [LICENSE](./LICENSE) file for more details.
 
+## Contributing
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+
+### How should I write my commits?
+
+This project uses [release please](https://github.com/googleapis/release-please) and [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for versioning releases.
+
+Per [release-please-action](https://github.com/google-github-actions/release-please-action):
+
+> The most important prefixes you should have in mind are:
+>
+> - `fix``: which represents bug fixes, and correlates to a SemVer patch.
+> - `feat``: which represents a new feature, and correlates to a SemVer minor.
+> - `feat!``:, or fix!:, refactor!:, etc., which represent a breaking change (indicated by the !) and will result in a SemVer major.
+
+Any PR with `fix`, `feat`, `docs`, or a conventional commit with an `!` will trigger a release PR when merged.
+
+Other conventional commits such as `chore`, `ci`, `test`, `refactor`, etc will not trigger a release but are encouraged to form a standard around conventional commits in the commit history.
+
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
@@ -123,8 +143,6 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- prettier-ignore-end -->
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
-
-This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
 
 ## Support 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "Flask-Muck"
-dynamic = ["version"]
+name = "flask-muck"
+version = "0.2.0"
 authors = [
   { name="Daniel Tiesling", email="tiesling@gmail.com" },
 ]

--- a/src/flask_muck/__init__.py
+++ b/src/flask_muck/__init__.py
@@ -1,4 +1,4 @@
 from .views import FlaskMuckApiView
 from .callback import FlaskMuckCallback
 
-VERSION = "0.2.0"
+__version__ = "0.2.0"


### PR DESCRIPTION
  > this introduces auto changelog, updating version via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), and modifies the publish action to use pyproject.toml for the current version.

  🚨 this assumes a secret exists for a PAT called `RELEASE_PLEASE_TOKEN` in order for release-please to trigger the publish action a token other than default `GITHUB_TOKEN` must be used.

chore: update the version in pyproject.toml to be 'statically' typed since it is managed by release-please.
chore: update the project name to lower case so release-please can find `src/{package_name}/__init__.py`.

  > this means that there is no reason to update hatch in the publish phase, since it will read in the pyproject version. `VERSION` was renamed to `__version__` to work with [release-please](https://github.com/googleapis/release-please/blob/main/src/updaters/python/python-file-with-version.ts#L20) and [hatch](https://hatch.pypa.io/latest/version/#configuration)--it is likely safe to remove `__version__` from `__init__.py` as well.

to manually override the initial release to match the latest published pypi package you can use `Release-As: 0.2.0` as a footer in a PR commit.

Release-As: 0.2.0