### PR TITLE
Add support for SQLAlchemy 1.4.

### DIFF
--- a/src/flask_muck/types.py
+++ b/src/flask_muck/types.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     # SQLAlchemy 1.4.x compatibility
     from sqlalchemy.orm import declarative_base
-    
+
     DeclarativeBase = declarative_base()
 
 

--- a/src/flask_muck/types.py
+++ b/src/flask_muck/types.py
@@ -2,12 +2,14 @@ from typing import Any, Union
 
 from marshmallow import Schema
 from pydantic import BaseModel
+
 try:
     # SQLAlchemy 2.x compatibility
     from sqlalchemy.orm import DeclarativeBase  # type: ignore
 except ImportError:
     # SQLAlchemy 1.4.x compatibility
     from sqlalchemy.orm import declarative_base
+    
     DeclarativeBase = declarative_base()
 
 

--- a/src/flask_muck/types.py
+++ b/src/flask_muck/types.py
@@ -2,7 +2,13 @@ from typing import Any, Union
 
 from marshmallow import Schema
 from pydantic import BaseModel
-from sqlalchemy.orm import DeclarativeBase  # type: ignore
+try:
+  # SQLAlchemy 2.x compatibility
+  from sqlalchemy.orm import DeclarativeBase  # type: ignore
+except ImportError:
+  # SQLAlchemy 1.4.x compatibility
+  from sqlalchemy.orm import declarative_base
+  DeclarativeBase = declarative_base()
 
 
 JsonDict = dict[str, Any]

--- a/src/flask_muck/types.py
+++ b/src/flask_muck/types.py
@@ -3,12 +3,12 @@ from typing import Any, Union
 from marshmallow import Schema
 from pydantic import BaseModel
 try:
-  # SQLAlchemy 2.x compatibility
-  from sqlalchemy.orm import DeclarativeBase  # type: ignore
+    # SQLAlchemy 2.x compatibility
+    from sqlalchemy.orm import DeclarativeBase  # type: ignore
 except ImportError:
-  # SQLAlchemy 1.4.x compatibility
-  from sqlalchemy.orm import declarative_base
-  DeclarativeBase = declarative_base()
+    # SQLAlchemy 1.4.x compatibility
+    from sqlalchemy.orm import declarative_base
+    DeclarativeBase = declarative_base()
 
 
 JsonDict = dict[str, Any]


### PR DESCRIPTION
While running Flask muck with Apache Airflow, which is using SQLAlchemy 1.4, this module throws an error indicating that DeclarativeBase does not exist.

I proceeded to make this change locally, and this worked as expected.